### PR TITLE
Removed warning messages when loading XSD

### DIFF
--- a/src/node_libxml_xsd.cc
+++ b/src/node_libxml_xsd.cc
@@ -13,6 +13,11 @@
 
 using namespace v8;
 
+void none(void *ctx, const char *msg, ...) {
+  // do nothing
+  return;
+}
+
 NAN_METHOD(SchemaSync) {
   	Nan::HandleScope scope;
 
@@ -22,6 +27,11 @@ NAN_METHOD(SchemaSync) {
     if (parser_ctxt == NULL) {
         return Nan::ThrowError("Could not create context for schema parser");
     }
+    xmlSchemaValidityErrorFunc err;
+    xmlSchemaValidityWarningFunc warn;
+    void* ctx;
+    xmlSchemaGetParserErrors(parser_ctxt, &err, &warn, &ctx);
+    xmlSchemaSetParserErrors(parser_ctxt, err, (xmlSchemaValidityWarningFunc) none, ctx);
     xmlSchemaPtr schema = xmlSchemaParse(parser_ctxt);
     if (schema == NULL) {
         return Nan::ThrowError("Invalid XSD schema");
@@ -47,6 +57,11 @@ class SchemaWorker : public Nan::AsyncWorker {
     libxmljs::WorkerSentinel workerSentinel(workerParent);
   	parser_ctxt = xmlSchemaNewDocParserCtxt(doc->xml_obj);
     if (parser_ctxt != NULL) {
+        xmlSchemaValidityErrorFunc err;
+        xmlSchemaValidityWarningFunc warn;
+        void* ctx;
+        xmlSchemaGetParserErrors(parser_ctxt, &err, &warn, &ctx);
+        xmlSchemaSetParserErrors(parser_ctxt, err, (xmlSchemaValidityWarningFunc) none, ctx);
         result = xmlSchemaParse(parser_ctxt);
     }
   }


### PR DESCRIPTION
When you load and already loaded schema (or an schema with a dependency already loaded), it prints a warning message on the stdout (it's part of libxml, so it can be controlled with node).

test2.xsd:3: element import: Schemas parser warning : Element '{http://www.w3.org/2001/XMLSchema}import': Skipping import of schema located at 'test.xsd' for the namespace '(null)', since this namespace was already imported with the schema located at 'in_memory_buffer'.

This pull request removes those warnings